### PR TITLE
Fix 読み上げ

### DIFF
--- a/src/Talk/index.ts
+++ b/src/Talk/index.ts
@@ -34,7 +34,7 @@ export default class Talk {
     port: '50080'
   }, options: TalkOptions = {
     speaker: '1',
-    speedScale: '1',
+    speedScale: '1.3',
     pitchScale: '0',
     intonationScale: '1',
     volumeScale: '1',

--- a/src/discord/events/readMessages.ts
+++ b/src/discord/events/readMessages.ts
@@ -101,7 +101,7 @@ class _ReadMessages {
   private fixText(text: string): string {
     // URLを省略する
     // const urlPattern = new RegExp(`https?://[\\w!?/+\\-_~;.,*&@#$%()'[\\]]+`);
-    const linkPattern = /\w+:\/\/[\w!?/+\\-_~;.,*&@#$%()'[\]=]+/g;
+    const linkPattern = /\w+:\/\/[\w!?/+\\\-_~;.,*&@#$%()'[\]=]+/g;
     text = text.replace(linkPattern, "ゆーあーるえる");
 
     // @everyone,@hereを置き換える

--- a/src/discord/events/readMessages.ts
+++ b/src/discord/events/readMessages.ts
@@ -145,7 +145,7 @@ class _ReadMessages {
     text = text.replace(emojiPattern, "$1");
 
     // Guild Navigationを置き換え
-    const guildNavigationPattern = /<id:(\d+)>/g;
+    const guildNavigationPattern = /<id:(customize|browse|guide|linked-roles)>/g;
     text = text.replace(guildNavigationPattern, (match, p1) => {
       switch(p1) {
         case "customize":

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,8 +10,12 @@ export default talk;
 const discord = new Discord();
 discord.start()
 
-process.on("SIGINT", async () => {
-  console.log("[main] SIGINT received. Exiting...");
+const gracefulShutdown = async (signal: string) => {
+  console.log(`[main] ${signal} received. Exiting...`);
   await discord.close();
   process.exit(0);
+};
+
+["SIGINT", "SIGTERM"].forEach((signal) => {
+  process.on(signal, () => gracefulShutdown(signal));
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,7 +8,6 @@ const talk = new Talk({
 export default talk;
 
 const discord = new Discord();
-discord.deployCommands();
 discord.start()
 
 process.on("SIGINT", async () => {


### PR DESCRIPTION
- <id:~~~>のマッチしない問題を修正
- deployしたときにコマンドを毎回登録する問題を修正
- デフォルトの読み上げスピードを1.3に変更
- SIGTERMの割り込み処理を追加
- URLに`-`が含まれていた場合にマッチしない問題を修正